### PR TITLE
fix: [figma-icon-plugin] svg 파일 이름 수정, placeholder 변경

### DIFF
--- a/packages/figma-icon-plugin/src/plugin/code.ts
+++ b/packages/figma-icon-plugin/src/plugin/code.ts
@@ -22,6 +22,18 @@ export const findAllComponentNode = (rootNode: SceneNode) => {
   return result
 }
 
+function convertSvgFileName(input) {
+  const match = input.match(/name=(.+)/);
+  
+  if (match && match[1]) {
+    const cleanedName = match[1].replace(/[-\s]/g, '');
+    const capitalizedName = cleanedName.charAt(0).toUpperCase() + cleanedName.slice(1);
+    return capitalizedName + 'Icon';
+  }
+  
+  return '';
+}
+
 async function extractIcon() {
   const componentNodes = figma.currentPage.selection
     .map(findAllComponentNode)
@@ -50,7 +62,14 @@ async function extractIcon() {
     if (!cur?.id) {
       return acc
     }
-    acc[cur.id] = cur
+
+    const name = convertSvgFileName(cur?.id);
+
+    if (!name) {
+      return acc
+    }
+
+    acc[name] = cur
     return acc
   }, {})
 

--- a/packages/figma-icon-plugin/src/ui/components/Publish.tsx
+++ b/packages/figma-icon-plugin/src/ui/components/Publish.tsx
@@ -1,9 +1,9 @@
 import React, { ChangeEvent, useEffect, useState } from 'react';
 import { Badge, Box, Button, Flex, Text, TextArea, TextField } from "@radix-ui/themes"
-import { GitHubData, SVGData } from '../type/type';
+import { SVGData } from '../type/type';
 import { uploadSVGsToGitHub } from '../../utils/githubApi';
 import { CalloutBox, CallOutInfo } from './CalloutBox';
-import { isEmptyObj } from '../../utils/util';
+import { increaseVersion, isEmptyObj } from '../../utils/util';
 import { Link1Icon } from '@radix-ui/react-icons';
 import { useGitHubData } from './GithubDataProvider';
 
@@ -24,8 +24,8 @@ export const Publish = () => {
   const { githubData, setGithubData: _ } = useGitHubData();
 
   const [newVersion, setNewVersion] = useState(githubData.packageJson.version ?? "");
-  const [commitMsg, setCommitMsg] = useState("");
-  const [uploadPath, setUploadPath] = useState("packages/figma-icon-plugin/asset");
+  const [commitMsg, setCommitMsg] = useState("Update Svg Asset");
+  const [uploadPath, setUploadPath] = useState("packages/fotcamp-icons/asset");
   const [svgData, setSvgData] = useState<SVGData>();
   const [isLoading, setIsLoading] = useState(false);
   const [calloutInfo, setCalloutInfo] = useState<CallOutInfo | null>(null);
@@ -59,7 +59,13 @@ export const Publish = () => {
     } else {
       setDisabled(true);
     }
-  }, [newVersion, commitMsg, uploadPath, svgData])
+  }, [newVersion, commitMsg, uploadPath, svgData]);
+
+  useEffect(() => {
+    const prevVersion = githubData.packageJson.version;
+    const increasedVersion = increaseVersion(prevVersion);
+    setNewVersion(increasedVersion);
+  }, [githubData]);
 
   const handleOnChange = (e: ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;

--- a/packages/figma-icon-plugin/src/utils/util.ts
+++ b/packages/figma-icon-plugin/src/utils/util.ts
@@ -7,3 +7,15 @@ export function isEmptyObj(obj)  {
   
   return false;
 }
+
+export function increaseVersion(version: string): string {
+  const parts = version.split('.');
+  
+  if (parts.length !== 3) {
+    return "";
+  }
+  
+  const patch = parseInt(parts[2], 10) + 1;
+  
+  return `${parts[0]}.${parts[1]}.${patch}`;
+}


### PR DESCRIPTION
## figma-icon-plugin

### 작업 사항
1. Publish > version, commit message placeholder 수정
    - version patch +1
3. 추출된 svg 파일 이름 수정
    - 첫 문자 대문자
    - Suffix Icon 추가

<img width="297" alt="image" src="https://github.com/user-attachments/assets/2a204b31-8697-4608-9e20-9975b8c56202">